### PR TITLE
Fix join error if nothing selected

### DIFF
--- a/event/main_listener.php
+++ b/event/main_listener.php
@@ -254,7 +254,7 @@ class main_listener implements EventSubscriberInterface
 	{
 		global $config, $user;
 
-		$total_new_string = array();
+		$total_news_string = array();
 		if ($config[PREFIXES::CONFIG . '_disp_new_topics'])
 		{
 			$total_news_string[] = $user->lang('ACTIVITY_STATS_NEW_TOPICS', $activity['new_topics']);


### PR DESCRIPTION
Removes error displayed on index page if nothing is selected in the ACP (aka de-nub what nub admins may do).
